### PR TITLE
Make MeasureCallback signature .NET friendly

### DIFF
--- a/dali-toolkit/devel-api/layouting/flex-node.cpp
+++ b/dali-toolkit/devel-api/layouting/flex-node.cpp
@@ -163,7 +163,7 @@ SizeTuple Node::MeasureNode( float width, int widthMode, float height, int heigh
   if( mImpl->mMeasureCallback && mImpl->mActor.GetHandle() )
   {
     DALI_LOG_INFO( gLogFilter, Debug::Verbose, "MeasureNode MeasureCallback executing on %s\n", mImpl->mActor.GetHandle().GetProperty< std::string >( Dali::Actor::Property::NAME ).c_str() );
-    nodeSize = mImpl->mMeasureCallback( mImpl->mActor.GetHandle(), width, widthMode, height, heightMode );
+    mImpl->mMeasureCallback( mImpl->mActor.GetHandle(), width, widthMode, height, heightMode, &nodeSize );
   }
   DALI_LOG_INFO( gLogFilter, Debug::Verbose, "MeasureNode nodeSize width:%f height:%f\n", nodeSize.width, nodeSize.height );
   return nodeSize;

--- a/dali-toolkit/devel-api/layouting/flex-node.h
+++ b/dali-toolkit/devel-api/layouting/flex-node.h
@@ -111,8 +111,9 @@ struct SizeTuple
  * @note int, width measure specifcation mode
  * @note float, available height for child
  * @note int, height measure specification mode
+ * @note SizeTuple, return value
  */
-using MeasureCallback = SizeTuple (*)( Dali::Actor, float , int , float , int );
+using MeasureCallback = void (*)( Dali::Actor, float , int , float , int, SizeTuple *);
 
 /**
  * This class provides the API for calling into the Flex layout implementation.


### PR DESCRIPTION
Currently, MeasureCallback signature has a return type of a POD 16 bytes
structure. Returning the structure by value is messing up when passing a
delegate from C# on Windows 10. The net effect is that arguments arrive
with random values. This happens because the C++ compiler may apply
optimization like RVO that the .NET runtime is not aware of.

This link [1] provides more details.

We fix the problem by making SizeTuple an out parameter and returning
void.

[1] https://www.tutorialsteacher.com/csharp/csharp-delegates